### PR TITLE
Add labeled headers to CSVs with no data

### DIFF
--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -104,7 +104,10 @@ class CSVRenderer(BaseRenderer):
 
         elif header:
             # If there's no data but a header was supplied, yield the header.
-            yield header
+            if labels:
+                yield [labels.get(x, x) for x in header]
+            else:
+                yield header
 
         else:
             # Generator will yield nothing if there's no data and no header


### PR DESCRIPTION
CSVs with no data should still use header labels
This change mirrors label behavior that occurs when there is data